### PR TITLE
Update copy-paste code

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This step adds Regolith's public key hosted in this repository into the local ap
 1. From a terminal, add the Regolith key to your apt keychain:
 
 ```bash
-$ wget -qO - https://regolith-linux.github.io/package-repo/regolith.key | sudo apt-key add -
+wget -qO - https://regolith-linux.github.io/package-repo/regolith.key | sudo apt-key add -
 ```
 
 ### Add Repo to Apt's Sources
@@ -19,10 +19,10 @@ $ wget -qO - https://regolith-linux.github.io/package-repo/regolith.key | sudo a
 1. Add this repository to your apt sources:
 
 ```bash
-$ export DISTRO=ubuntu    # choose either 'ubuntu' or 'debian' here depending on system installing into
-$ export CODENAME=hirsute # choose either 'focal' or 'hirsute' for ubuntu or 'buster' or 'bullseye' for debian
-$ export ARCH=amd64       # choose either amd64 or arm64
-$ echo deb [arch=amd64] https://regolith-linux.github.io/package-repo/$DISTRO/$CODENAME/$ARCH $CODENAME main | sudo tee /etc/apt/sources.list.d/regolith.list
+export DISTRO=ubuntu    # choose either 'ubuntu' or 'debian' here depending on system installing into
+export CODENAME=hirsute # choose either 'focal' or 'hirsute' for ubuntu or 'buster' or 'bullseye' for debian
+export ARCH=amd64       # choose either amd64 or arm64
+echo deb [arch=amd64] https://regolith-linux.github.io/package-repo/$DISTRO/$CODENAME/$ARCH $CODENAME main | sudo tee /etc/apt/sources.list.d/regolith.list
 ```
 
 ### Install Regolith
@@ -30,13 +30,13 @@ $ echo deb [arch=amd64] https://regolith-linux.github.io/package-repo/$DISTRO/$C
 1. Update your apt state:
 
 ```bash
-$ sudo apt update
+sudo apt update
 ```
 
 2. Install Regolith desktop
 
 ```bash
-$ sudo apt install regolith-desktop-small
+sudo apt install regolith-desktop-small
 ```
 
 


### PR DESCRIPTION
When copying from the README, either selecting or using the in-line copy icon, the text includes a leading $ which then needs to be removed before running locally.

Remove to make life simpler.